### PR TITLE
Fix EU event-log fallback to query EU host

### DIFF
--- a/pubsub/src/main/java/com/fastcomments/pubsub/LiveEventSubscriber.java
+++ b/pubsub/src/main/java/com/fastcomments/pubsub/LiveEventSubscriber.java
@@ -202,7 +202,7 @@ public class LiveEventSubscriber {
 
             // Fetch missed events if we have a last event time
             if (lastEventTime > 0) {
-                fetchEventLog(tenantId, urlId, userIdWS, lastEventTime, new Date().getTime(),
+                fetchEventLog(config.region, tenantId, urlId, userIdWS, lastEventTime, new Date().getTime(),
                         events -> processEvents(events, canSeeCommentsCallback, handleLiveEvent));
             }
 
@@ -253,7 +253,7 @@ public class LiveEventSubscriber {
 
             // Fetch missed events if we have a last event time
             if (lastEventTime > 0) {
-                fetchEventLog(tenantId, urlId, userIdWS, lastEventTime, new Date().getTime(),
+                fetchEventLog(config.region, tenantId, urlId, userIdWS, lastEventTime, new Date().getTime(),
                         events -> processEvents(events, canSeeCommentsCallback, handleLiveEvent));
             }
         }
@@ -323,6 +323,7 @@ public class LiveEventSubscriber {
      * Fetch event log from API using PublicApi client
      */
     private static void fetchEventLog(
+            String region,
             String tenantId,
             String urlId,
             String userIdWS,
@@ -331,8 +332,13 @@ public class LiveEventSubscriber {
             Consumer<List<LiveEvent>> callback
     ) {
         try {
-            // Create PublicApi instance with its own HTTP client
-            PublicApi publicApi = new PublicApi(new ApiClient(httpClient));
+            // Create PublicApi instance with its own HTTP client, pointed at the region's host
+            // so the "fetch missed events" fallback queries EU infra for EU tenants instead of US.
+            ApiClient apiClient = new ApiClient(httpClient);
+            if (Objects.equals(region, "eu")) {
+                apiClient.setBasePath("https://eu.fastcomments.com");
+            }
+            PublicApi publicApi = new PublicApi(apiClient);
 
             // Create API request
             PublicApi.APIgetEventLogRequest request =


### PR DESCRIPTION
## Problem

`subscribeToChanges` correctly routes the live WebSocket to `wss://ws-eu.fastcomments.com` for EU tenants (`config.region == "eu"`), but the "fetch missed events" REST fallback (`fetchEventLog`) always built its `PublicApi` against the default host `https://fastcomments.com`:

```java
PublicApi publicApi = new PublicApi(new ApiClient(httpClient)); // default host, no region switch
```

For EU tenants this silently queries US infra and gets nothing back, so any events missed while disconnected (the whole point of the fallback) are never replayed.

## Fix

Thread `config.region` into `fetchEventLog` and point the `ApiClient` at `https://eu.fastcomments.com` when the region is `"eu"` (the EU host already exists in the generated client's server list).

## Testing

`:pubsub:compileJava` builds cleanly against the local client via the CI init script:

```
./core/gradlew :pubsub:compileJava --init-script ci-local-client.gradle --no-daemon
BUILD SUCCESSFUL
```

## Notes

The same bug was found and fixed in the Python SDK; this brings the Java SDK in line for EU tenants.